### PR TITLE
FontRenderer.stripColor is now more efficient (notch y u do dis)

### DIFF
--- a/src/main/java/com/mojang/minecraft/gui/FontRenderer.java
+++ b/src/main/java/com/mojang/minecraft/gui/FontRenderer.java
@@ -12,19 +12,8 @@ import com.mojang.minecraft.render.ShapeRenderer;
 import com.mojang.minecraft.render.TextureManager;
 
 public final class FontRenderer {
-	public static String stripColor(String var0) {
-		char[] var3 = var0.toCharArray();
-		String var1 = "";
-
-		for (int var2 = 0; var2 < var3.length; ++var2) {
-			if (var3[var2] == 38) {
-				++var2;
-			} else {
-				var1 = var1 + var3[var2];
-			}
-		}
-
-		return var1;
+	public static String stripColor(String str) {
+		return str.replace("&", "");
 	}
 
 	public int charHeight;


### PR DESCRIPTION
I can see how this behaviour of only replacing ampersands (and not the color code that follow) can result in random numbers/characters before the player's name, but I'm not sure what side effects there are by changing this behaviour, so I am keeping this intact for now.
