### PR TITLE
Removed double-tap-to-fly toggle

### DIFF
--- a/src/main/java/com/mojang/minecraft/Minecraft.java
+++ b/src/main/java/com/mojang/minecraft/Minecraft.java
@@ -295,8 +295,7 @@ public final class Minecraft implements Runnable {
 	public MonitoringThread monitoringThread;
 	public int tempDisplayWidth;
 	public int tempDisplayHeight;
-	public boolean canRenderGUI = true;        
-        public int flyToggleTimer = 7;
+	public boolean canRenderGUI = true;
 
 	private static void checkGLError(String var0) {
 		int var1;
@@ -3432,11 +3431,6 @@ public final class Minecraft implements Runnable {
 			if (blockHitTime > 0) {
 				--blockHitTime;
 			}
-                        
-                        if (flyToggleTimer > 0)
-                        {
-                            --flyToggleTimer;
-                        }  
 
 			while (Keyboard.next()) {
 				player.setKey(Keyboard.getEventKey(),
@@ -3518,19 +3512,6 @@ public final class Minecraft implements Runnable {
 										player.hovered = !player.hovered;
 									}
 								}
-                                                                if (HackState.Fly && Keyboard.getEventKey() == settings.jumpKey.key)
-                                                                {
-                                                                    if (flyToggleTimer == 0)
-                                                                    {
-                                                                        this.flyToggleTimer = 7;
-                                                                    }
-                                                                    else
-                                                                    {
-                                                                        player.flyingMode = !player.flyingMode;
-                                                                        this.flyToggleTimer = 0;
-                                                                    }
-                                                                }
-
 								if (Keyboard.getEventKey() == Keyboard.KEY_Z) {
 									if (HackState.Fly) {
 										player.flyingMode = !player.flyingMode;


### PR DESCRIPTION
No one asked for this. There are lots of valid reasons to spam jump in classic.
