### PR TITLE
GameSettings and Options GUI overhaul.

### DIFF
--- a/src/main/java/com/mojang/minecraft/GameSettings.java
+++ b/src/main/java/com/mojang/minecraft/GameSettings.java
@@ -1,19 +1,15 @@
 package com.mojang.minecraft;
 
-import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.FileWriter;
-import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Serializable;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.HashMap;
 import java.util.List;
-
-import javax.imageio.ImageIO;
 
 import org.lwjgl.input.Keyboard;
 import org.lwjgl.opengl.Display;
@@ -21,29 +17,30 @@ import org.lwjgl.opengl.Display;
 import com.mojang.minecraft.render.TextureManager;
 
 public final class GameSettings implements Serializable {
-
-    private static final long serialVersionUID = 1L;
+    private static final long serialVersionUID = 2L;
     public static String StatusString = "";
     public static String PercentString = "";
 
+    public static String[] smoothingOptions
+            = new String[]{"OFF", "Automatic", "Universal"};
+    private static final String[] viewDistanceOptions
+            = new String[]{"FAR", "NORMAL", "SHORT", "TINY"};
+    
+
     public static boolean CanReplaceSlot = true;
 
-    public static List<String> typinglog = new ArrayList<String>();
+    public static List<String> typinglog = new ArrayList<>();
     public static int typinglogpos = 0;
 
-    private static final String[] renderDistances = new String[] { "FAR", "NORMAL", "SHORT", "TINY" };
-
-    public boolean music = true;
-    public boolean sound = true;
-    public boolean invertMouse = false;
-    public boolean canServerChangeTextures = true;
-    public boolean showDebug = false;
-    public int viewDistance = 0;
-    public boolean viewBobbing = true;
     public boolean showClouds = true;
-    public boolean anaglyph = false;
-    public boolean limitFramerate = true;
     public byte thirdPersonMode = 0;
+    public boolean CanSpeed = true;
+    
+    public transient Minecraft minecraft;
+    private final File settingsFile;
+    public int settingCount;
+    
+    //==== BINDINGS ===============================================================================
     public KeyBinding forwardKey = new KeyBinding("Forward", 17);
     public KeyBinding leftKey = new KeyBinding("Left", 30);
     public KeyBinding backKey = new KeyBinding("Back", 31);
@@ -55,323 +52,286 @@ public final class GameSettings implements Serializable {
     public KeyBinding saveLocationKey = new KeyBinding("Save location", 28);
     public KeyBinding loadLocationKey = new KeyBinding("Load location", 19);
     public KeyBinding runKey = new KeyBinding("Run", 42);
-    public KeyBinding[] bindings;
-        public KeyBinding[] bindingsmore;
-    public transient Minecraft minecraft;
-    private File settingsFile;
-    public int settingCount;
-    public boolean CanSpeed = true;
-    public int HackType = 0;
-    public int ShowNames = 0;
-
-    public String lastUsedTexturePack;
-
-    public boolean HacksEnabled = true;
-
-    public int smoothing = 0;
-
-    public String[] smoothingOptions = new String[] { "OFF", "Automatic", "Universal" };
-    public int anisotropic = 0;
-
-    public float scale = 1.0f;
-
-    public String[] anisotropicOptions = new String[] { "OFF", "ON" };
     public KeyBinding flyKey = new KeyBinding("Fly", Keyboard.KEY_Z);
-
     public KeyBinding flyUp = new KeyBinding("Fly Up", Keyboard.KEY_Q);
     public KeyBinding flyDown = new KeyBinding("Fly Down", Keyboard.KEY_E);
     public KeyBinding noClip = new KeyBinding("NoClip", Keyboard.KEY_X);
+    public KeyBinding[] bindings;
+    public KeyBinding[] bindingsmore;
+    
+    //==== SETTINGS ===============================================================================
+    public int HackType = 0;
+    public int ShowNames = 0;
+    public String lastUsedTexturePack;
+    public boolean HacksEnabled = true;
+    public int smoothing = 0;
+    public boolean limitFramerate = true;
+    public boolean viewBobbing = true;
+    public int viewDistance;
+    
+    // 0 = off, higher values mean powers-of-2 (e.g. 1=>2x, 2=>4x, 3=>8x, 4=>16x)
+    public int anisotropy;
+    
+    // Interface font scale, as a ratio of default font (1.0 => 100%)
+    public float scale = 1;
+    public boolean music = true;
+    public boolean sound = true;
+    public boolean invertMouse = false;
+    public boolean canServerChangeTextures = true;
+    public boolean showDebug = false;
+
 
     public GameSettings(Minecraft minecraft, File minecraftFolder) {
-        bindings = new KeyBinding[] { forwardKey, leftKey, backKey, rightKey, jumpKey,
-                inventoryKey, chatKey, toggleFogKey, saveLocationKey, loadLocationKey };
-                bindingsmore = new KeyBinding[] { runKey, flyKey, flyUp, flyDown, noClip};
-
-        settingCount = 15;
+        bindings = new KeyBinding[]{
+            forwardKey, leftKey, backKey, rightKey, jumpKey,
+            inventoryKey, chatKey, toggleFogKey, saveLocationKey, loadLocationKey};
+        bindingsmore = new KeyBinding[]{runKey, flyKey, flyUp, flyDown, noClip};
 
         this.minecraft = minecraft;
 
         settingsFile = new File(minecraftFolder, "options.txt");
-
         load();
     }
 
     public String getBinding(int key) {
         return bindings[key].name + ": " + Keyboard.getKeyName(bindings[key].key);
     }
-        public String getBindingMore(int key) {
+
+    public String getBindingMore(int key) {
         return bindingsmore[key].name + ": " + Keyboard.getKeyName(bindingsmore[key].key);
     }
 
-    public String getSetting(int id) {
-        return id == 0 ? "Music: " + (music ? "ON" : "OFF") : id == 1 ? "Sound: "
-                + (sound ? "ON" : "OFF") : id == 2 ? "Invert mouse: "
-                + (invertMouse ? "ON" : "OFF") : id == 3 ? "Show Debug: "
-                + (showDebug ? "ON" : "OFF") : id == 4 ? "Render distance: "
-                + renderDistances[viewDistance] : id == 5 ? "View bobbing: "
-                + (viewBobbing ? "ON" : "OFF") : id == 6 ? "3d anaglyph: "
-                + (anaglyph ? "ON" : "OFF") : id == 7 ? "Limit framerate: "
-                + (limitFramerate ? "ON" : "OFF") : id == 8 ? "Smoothing: "
-                + smoothingOptions[smoothing] : id == 9 ? "Anisotropic: "
-                + anisotropicOptions[anisotropic] : id == 10 ? "Allow server textures: "
-                + (canServerChangeTextures ? "Yes" : "No") : id == 11 ? "SpeedHack Type: "
-                + (HackType == 0 ? "Normal" : "Adv") : id == 12 ? "Font Scale: "
-                + new DecimalFormat("#.#").format(scale) : id == 13 ? "Enable Hacks: "
-                + (HacksEnabled ? "Yes" : "No") : id == 14 ? "Show Names: "
-                + (ShowNames == 0 ? "Hover" : "Always") : "";
+    private static String toOnOff(boolean value) {
+        return (value ? "ON" : "OFF");
+    }
+
+    public String getSetting(Setting id) {
+        switch (id) {
+            case MUSIC:
+                return "Music: " + toOnOff(music);
+            case SOUND:
+                return "Sound: " + toOnOff(sound);
+            case INVERT_MOUSE:
+                return "Invert mouse: " + toOnOff(invertMouse);
+            case SHOW_DEBUG:
+                return "Show Debug: " + toOnOff(showDebug);
+            case RENDER_DISTANCE:
+                return "Render distance: " + viewDistanceOptions[viewDistance];
+            case VIEW_BOBBING:
+                return "View bobbing: " + toOnOff(viewBobbing);
+            case LIMIT_FRAMERATE:
+                return "Limit framerate: " + toOnOff(limitFramerate);
+            case SMOOTHING:
+                return "Smoothing: " + smoothingOptions[smoothing];
+            case ANISOTROPIC:
+                return "Anisotropic: " + (anisotropy == 0 ? "OFF" : (1<<anisotropy) + "x");
+            case ALLOW_SERVER_TEXTURES:
+                return "Allow server textures: " + (canServerChangeTextures ? "Yes" : "No");
+            case SPEEDHACK_TYPE:
+                return "SpeedHack type: " + (HackType == 0 ? "Normal" : "Adv");
+            case FONT_SCALE:
+                return "Font Scale: " + new DecimalFormat("#.#").format(scale);
+            case ENABLE_HACKS:
+                return "Enable Hacks: " + (HacksEnabled ? "Yes" : "No");
+            case SHOW_NAMES:
+                return "Show Names: " + (ShowNames == 0 ? "Hover" : "Always");
+            default:
+                throw new IllegalArgumentException();
+        }
     }
 
     private void load() {
         try {
             if (settingsFile.exists()) {
-                FileReader fileReader = new FileReader(settingsFile);
-                BufferedReader reader = new BufferedReader(fileReader);
-
-                String line = null;
-
-                while ((line = reader.readLine()) != null) {
-                    String[] setting = line.split(":");
-
-                    if (setting[0].equals("music")) {
-                        music = setting[1].equals("true");
+                try (FileReader fileReader = new FileReader(settingsFile)) {
+                    BufferedReader reader = new BufferedReader(fileReader);
+                    HashMap<String, String> rawSettings = new HashMap<>();
+                    String line;
+                    while ((line = reader.readLine()) != null) {
+                        String[] setting = line.split(":");
+                        rawSettings.put(setting[0].toLowerCase(), setting[1]);
                     }
-
-                    if (setting[0].equals("sound")) {
-                        sound = setting[1].equals("true");
-                    }
-
-                    if (setting[0].equals("invertYMouse")) {
-                        invertMouse = setting[1].equals("true");
-                    }
-
-                    if (setting[0].equals("showDebug")) {
-                        showDebug = setting[1].equals("true");
-                    }
-
-                    if (setting[0].equals("viewDistance")) {
-                        viewDistance = Integer.parseInt(setting[1]);
-                    }
-
-                    if (setting[0].equals("bobView")) {
-                        viewBobbing = setting[1].equals("true");
-                    }
-
-                    if (setting[0].equals("anaglyph3d")) {
-                        anaglyph = setting[1].equals("true");
-                    }
-
-                    if (setting[0].equals("limitFramerate")) {
-                        limitFramerate = setting[1].equals("true");
-                        Display.setVSyncEnabled(limitFramerate);
-                    }
-
-                    if (setting[0].equals("smoothing")) {
-                        smoothing = Integer.parseInt(setting[1]);
-                    }
-
-                    if (setting[0].equals("anisotropic")) {
-                        anisotropic = Integer.parseInt(setting[1]);
-                    }
-                    if (setting[0].equals("canServerChangeTextures")) {
-                        canServerChangeTextures = setting[1].equals("true");
-                    }
-                    if (setting[0].equals("HackType")) {
-                        HackType = Integer.parseInt(setting[1]);
-                    }
-                    if (setting[0].equals("Scale")) {
-                        scale = Float.parseFloat(setting[1]);
-                    }
-                    if (setting[0].equals("HacksEnabled")) {
-                        HacksEnabled = setting[1].equals("true");
-                    }
-                    if (setting[0].equals("ShowNames")) {
-                        ShowNames = Integer.parseInt(setting[1]);
-                    }
-                    if (setting[0].equals("texturepack")) {
-                        lastUsedTexturePack = setting[1];
-                    }
-                    for (KeyBinding binding : bindings) {
-                        if (setting[0].equals("key_" + binding.name)) {
-                            binding.key = Integer.parseInt(setting[1]);
-                        }
-                    }
+                    parseLoadedSettings(rawSettings);
                 }
-
-                reader.close();
             }
         } catch (Exception e) {
             System.out.println("Failed to load options");
-
             e.printStackTrace();
+        }
+    }
+
+    private void parseLoadedSettings(HashMap<String, String> settings) {
+        for (String key : settings.keySet()) {
+            String value = settings.get(key);
+            boolean isTrue = "true".equalsIgnoreCase(value) || "1".equals(value);
+            switch (value) {
+                case "music":
+                    music = isTrue;
+                    break;
+                case "sound":
+                    sound = isTrue;
+                    break;
+                case "invertymouse":
+                    invertMouse = isTrue;
+                    break;
+                case "showdebug":
+                    showDebug = isTrue;
+                    break;
+                case "viewdistance":
+                    viewDistance = Math.min( Math.max(Integer.parseInt(value), 0),
+                            viewDistanceOptions.length - 1);
+                    break;
+                case "bobview":
+                    viewBobbing = isTrue;
+                    break;
+                case "limitframerate":
+                    limitFramerate = isTrue;
+                    Display.setVSyncEnabled(limitFramerate);
+                    break;
+                case "smoothing":
+                    smoothing = Integer.parseInt(value);
+                    break;
+                case "anisotropic":
+                    smoothing = Integer.parseInt(value);
+                    break;
+                case "canserverchangetextures":
+                    canServerChangeTextures = isTrue;
+                    break;
+                case "hacktype":
+                    HackType = Integer.parseInt(value);
+                    break;
+                case "scale":
+                    scale = Float.parseFloat(value);
+                    break;
+                case "hacksenabled":
+                    HacksEnabled = isTrue;
+                    break;
+                case "shownames":
+                    ShowNames = Integer.parseInt(value);
+                    break;
+                case "texturepack":
+                    lastUsedTexturePack = value;
+                    break;
+                default:
+                    for (KeyBinding binding : bindings) {
+                        if (("key_" + binding.name.toLowerCase()).equals(value)) {
+                            binding.key = Integer.parseInt(value);
+                            break;
+                        }
+                    }
+                    break;
+            }
         }
     }
 
     public void save() {
         try {
-            FileWriter fileWriter = new FileWriter(settingsFile);
-            PrintWriter writer = new PrintWriter(fileWriter);
+            try (FileWriter fileWriter = new FileWriter(settingsFile)) {
+                PrintWriter writer = new PrintWriter(fileWriter);
 
-            writer.println("music:" + music);
-            writer.println("sound:" + sound);
-            writer.println("invertYMouse:" + invertMouse);
-            writer.println("showDebug:" + showDebug);
-            writer.println("viewDistance:" + viewDistance);
-            writer.println("bobView:" + viewBobbing);
-            writer.println("anaglyph3d:" + anaglyph);
-            writer.println("limitFramerate:" + limitFramerate);
-            writer.println("smoothing:" + smoothing);
-            writer.println("anisotropic:" + anisotropic);
-            writer.println("canServerChangeTextures:" + canServerChangeTextures);
-            writer.println("HackType:" + HackType);
-            writer.println("Scale:" + scale);
-            writer.println("HacksEnabled:" + HacksEnabled);
-            writer.println("ShowNames:" + ShowNames);
-            writer.println("texturepack:" + lastUsedTexturePack);
-            for (KeyBinding binding : bindings) {
-                writer.println("key_" + binding.name + ":" + binding.key);
+                writer.println("music:" + music);
+                writer.println("sound:" + sound);
+                writer.println("invertYMouse:" + invertMouse);
+                writer.println("showDebug:" + showDebug);
+                writer.println("viewDistance:" + viewDistance);
+                writer.println("bobView:" + viewBobbing);
+                writer.println("limitFramerate:" + limitFramerate);
+                writer.println("smoothing:" + smoothing);
+                writer.println("anisotropic:" + anisotropy);
+                writer.println("canServerChangeTextures:" + canServerChangeTextures);
+                writer.println("HackType:" + HackType);
+                writer.println("Scale:" + scale);
+                writer.println("HacksEnabled:" + HacksEnabled);
+                writer.println("ShowNames:" + ShowNames);
+                writer.println("texturepack:" + lastUsedTexturePack);
+                for (KeyBinding binding : bindings) {
+                    writer.println("key_" + binding.name + ":" + binding.key);
+                }
             }
-
-            writer.close();
         } catch (Exception e) {
             System.out.println("Failed to save options");
-
             e.printStackTrace();
         }
     }
 
     public void setBinding(int key, int keyID) {
         bindings[key].key = keyID;
-
         save();
     }
 
-        public void setBindingMore(int key, int keyID) {
+    public void setBindingMore(int key, int keyID) {
         bindingsmore[key].key = keyID;
-
         save();
     }
 
-    public void toggleSetting(int setting, int fogValue) {
-        if (setting == 0) {
-            music = !music;
-        }
-
-        if (setting == 1) {
-            sound = !sound;
-        }
-
-        if (setting == 2) {
-            invertMouse = !invertMouse;
-        }
-
-        if (setting == 3) {
-            showDebug = !showDebug;
-        }
-
-        if (setting == 4) {
-            viewDistance = viewDistance + fogValue & 3;
-        }
-
-        if (setting == 5) {
-            viewBobbing = !viewBobbing;
-        }
-
-        if (setting == 6) {
-            anaglyph = !anaglyph;
-
-            TextureManager textureManager = minecraft.textureManager;
-            Iterator<?> iterator = minecraft.textureManager.textureImages.keySet().iterator();
-
-            int i;
-            BufferedImage image;
-
-            while (iterator.hasNext()) {
-                i = (Integer) iterator.next();
-                image = textureManager.textureImages.get(Integer.valueOf(i));
-
-                textureManager.load(image, i);
-            }
-
-            iterator = textureManager.textures.keySet().iterator();
-
-            while (iterator.hasNext()) {
-                String s = (String) iterator.next();
-
-                try {
-                    if (s.startsWith("##")) {
-                        image = TextureManager.load1(ImageIO.read(TextureManager.class
-                                .getResourceAsStream(s.substring(2))));
-                    } else {
-                        image = ImageIO.read(TextureManager.class.getResourceAsStream(s));
-                    }
-
-                    i = textureManager.textures.get(s);
-
-                    textureManager.load(image, i);
-                } catch (IOException var6) {
-                    var6.printStackTrace();
+    public void toggleSetting(Setting setting, int fogValue) {
+        switch (setting) {
+            case MUSIC:
+                music = !music;
+                break;
+            case SOUND:
+                sound = !sound;
+                break;
+            case INVERT_MOUSE:
+                invertMouse = !invertMouse;
+                break;
+            case SHOW_DEBUG:
+                showDebug = !showDebug;
+                break;
+            case RENDER_DISTANCE:
+                int newViewDist = viewDistance + fogValue;
+                if (newViewDist < 0) {
+                    newViewDist = viewDistanceOptions.length-1;
+                }else{
+                    newViewDist = newViewDist % viewDistanceOptions.length;
                 }
-            }
+                viewDistance = newViewDist;
+                break;
+            case VIEW_BOBBING:
+                viewBobbing = !viewBobbing;
+                break;
+            case LIMIT_FRAMERATE:
+                limitFramerate = !limitFramerate;
+                if (Display.isCreated()) {
+                    Display.setVSyncEnabled(limitFramerate);
+                }
+                break;
+            case SMOOTHING:
+                smoothing = (smoothing + 1) % smoothingOptions.length;
+                minecraft.textureManager.textures.clear();
+                // minecraft.levelRenderer.refresh(); // (?)
+                break;
+            case ANISOTROPIC:
+                anisotropy = (anisotropy + 1) % TextureManager.getMaxAnisotropySetting();
+                minecraft.textureManager.textures.clear();
+                break;
+            case ALLOW_SERVER_TEXTURES:
+                canServerChangeTextures = !canServerChangeTextures;
+                break;
+            case SPEEDHACK_TYPE:
+                if (HackType == 1) {
+                    HackType = 0;
+                } else {
+                    HackType++;
+                }
+                break;
+            case FONT_SCALE:
+                scale += 0.1;
+                if (scale > 1.2f) {
+                    scale = 0.6f;
+                }
+                break;
+            case ENABLE_HACKS:
+                HacksEnabled = !HacksEnabled;
+                break;
+            case SHOW_NAMES:
+                if (ShowNames == 0) {
+                    ShowNames = 1;
+                } else {
+                    ShowNames = 0;
+                }
+                break;
         }
-
-        if (setting == 7) {
-            limitFramerate = !limitFramerate;
-            if (Display.isCreated()) {
-                Display.setVSyncEnabled(limitFramerate);
-            }
-        }
-
-        if (setting == 8) {
-            if (smoothing == smoothingOptions.length - 1) {
-                smoothing = 0;
-            } else {
-                smoothing++;
-            }
-
-            minecraft.textureManager.textures.clear();
-
-            // minecraft.levelRenderer.refresh();
-        }
-
-        if (setting == 9) {
-            if (anisotropic == anisotropicOptions.length - 1) {
-                anisotropic = 0;
-            } else {
-                anisotropic++;
-            }
-
-            minecraft.textureManager.textures.clear();
-
-            // minecraft.levelRenderer.refresh();
-        }
-        if (setting == 10) {
-            canServerChangeTextures = !canServerChangeTextures;
-        }
-        if (setting == 11) {
-            if (HackType == 1) {
-                HackType = 0;
-            } else {
-                HackType++;
-            }
-        }
-        if (setting == 12) {
-            scale += 0.1;
-            if (scale > 1.2f) {
-                scale = 0.6f;
-            }
-        }
-        if (setting == 13) {
-            HacksEnabled = !HacksEnabled;
-        }
-        if (setting == 14) {
-            if (ShowNames == 0) {
-                ShowNames = 1;
-            } else {
-                ShowNames = 0;
-            }
-        }
-
         save();
     }
-
 }

--- a/src/main/java/com/mojang/minecraft/Minecraft.java
+++ b/src/main/java/com/mojang/minecraft/Minecraft.java
@@ -1525,7 +1525,7 @@ public final class Minecraft implements Runnable {
                             GL11.glDisable(GL11.GL_CULL_FACE);
                                 // GL11.glBegin(GL11.GL_QUADS);
 
-                                // Front Face
+                            // Front Face
                             // Bottom Left
                             shapeRenderer.begin();
                             shapeRenderer.vertex(bounds.x0, bounds.y0, bounds.z1);
@@ -1536,7 +1536,7 @@ public final class Minecraft implements Runnable {
                             // Top Left
                             shapeRenderer.vertex(bounds.x0, bounds.y1, bounds.z1);
 
-                                // Back Face
+                            // Back Face
                             // Bottom Right
                             shapeRenderer.vertex(bounds.x0, bounds.y0, bounds.z0);
                             // Top Right
@@ -1546,7 +1546,7 @@ public final class Minecraft implements Runnable {
                             // Bottom Left
                             shapeRenderer.vertex(bounds.x1, bounds.y0, bounds.z0);
 
-                                // Top Face
+                            // Top Face
                             // Top Left
                             // Bottom Left
                             shapeRenderer.vertex(bounds.x0, bounds.y1, bounds.z0);
@@ -1556,7 +1556,7 @@ public final class Minecraft implements Runnable {
                             // Top Right
                             shapeRenderer.vertex(bounds.x1, bounds.y1, bounds.z0);
 
-                                // Bottom Face
+                            // Bottom Face
                             // Top Right
                             shapeRenderer.vertex(bounds.x0, bounds.y0, bounds.z0);
                             // Top Left
@@ -1566,7 +1566,7 @@ public final class Minecraft implements Runnable {
                             // Bottom Right
                             shapeRenderer.vertex(bounds.x0, bounds.y0, bounds.z1);
 
-                                // Right face
+                            // Right face
                             // Bottom Right
                             shapeRenderer.vertex(bounds.x1, bounds.y0, bounds.z0);
                             // Top Right
@@ -1576,7 +1576,7 @@ public final class Minecraft implements Runnable {
                             // Bottom Left
                             shapeRenderer.vertex(bounds.x1, bounds.y0, bounds.z1);
 
-                                // Left Face
+                            // Left Face
                             // Bottom Left
                             shapeRenderer.vertex(bounds.x0, bounds.y0, bounds.z0);
                             // Bottom Right
@@ -2114,8 +2114,7 @@ public final class Minecraft implements Runnable {
         TextureManager texManager = textureManager;
 
         for (var16 = 0; var16 < texManager.animations.size(); ++var16) {
-            TextureFX texFX;
-            (texFX = texManager.animations.get(var16)).anaglyph = texManager.settings.anaglyph;
+            TextureFX texFX = texManager.animations.get(var16);
             texFX.animate();
             if (texManager.textureBuffer.capacity() != texFX.textureData.length) {
                 texManager.textureBuffer = BufferUtils
@@ -3188,7 +3187,7 @@ public final class Minecraft implements Runnable {
                     if (Keyboard.getEventKey() == settings.toggleFogKey.key) {
                         boolean shiftDown = Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)
                                 || Keyboard.isKeyDown(Keyboard.KEY_RSHIFT);
-                        settings.toggleSetting(4, shiftDown ? -1 : 1);
+                        settings.toggleSetting(Setting.RENDER_DISTANCE, shiftDown ? -1 : 1);
                     }
                 }
             }

--- a/src/main/java/com/mojang/minecraft/Setting.java
+++ b/src/main/java/com/mojang/minecraft/Setting.java
@@ -1,0 +1,18 @@
+package com.mojang.minecraft;
+
+public enum Setting {
+    MUSIC,
+    SOUND,
+    INVERT_MOUSE,
+    SHOW_DEBUG,
+    RENDER_DISTANCE,
+    VIEW_BOBBING,
+    LIMIT_FRAMERATE,
+    SMOOTHING,
+    ANISOTROPIC,
+    ALLOW_SERVER_TEXTURES,
+    SPEEDHACK_TYPE,
+    FONT_SCALE,
+    ENABLE_HACKS,
+    SHOW_NAMES
+}

--- a/src/main/java/com/mojang/minecraft/gui/AdvancedOptionsScreen.java
+++ b/src/main/java/com/mojang/minecraft/gui/AdvancedOptionsScreen.java
@@ -4,6 +4,7 @@ import java.awt.Color;
 
 import com.mojang.minecraft.ColorCache;
 import com.mojang.minecraft.GameSettings;
+import com.mojang.minecraft.Setting;
 import com.mojang.minecraft.gui.inputscreens.FogColorInputScreen;
 import com.mojang.minecraft.gui.inputscreens.LightColorInputScreen;
 import com.mojang.minecraft.gui.inputscreens.ShadowColorInputScreen;
@@ -12,12 +13,18 @@ import com.mojang.minecraft.gui.inputscreens.WaterLevelInputScreen;
 
 public final class AdvancedOptionsScreen extends GuiScreen {
 
+    private final static Setting[] settingsOrder = new Setting[]{
+        Setting.ENABLE_HACKS,
+        Setting.SPEEDHACK_TYPE,
+        Setting.ALLOW_SERVER_TEXTURES,
+        Setting.SHOW_DEBUG
+    };
+
     public static String decToHex(int dec) {
         int sizeOfIntInHalfBytes = 8;
         int numberOfBitsInAHalfByte = 4;
         int halfByte = 0x0F;
-        char[] hexDigits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
-                'E', 'F' };
+        char[] hexDigits = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
         StringBuilder hexBuilder = new StringBuilder(sizeOfIntInHalfBytes);
         hexBuilder.setLength(sizeOfIntInHalfBytes);
         for (int i = sizeOfIntInHalfBytes - 1; i >= 0; --i) {
@@ -28,34 +35,35 @@ public final class AdvancedOptionsScreen extends GuiScreen {
         return hexBuilder.toString();
     }
 
-    private GuiScreen parent;
-    private String title = "Advanced Options";
-    private GameSettings settings;
+    private final GuiScreen parent;
+    private final String title = "Advanced Options";
+    private final GameSettings settings;
 
-    public AdvancedOptionsScreen(GuiScreen var1, GameSettings var2) {
-        parent = var1;
-        settings = var2;
+    public AdvancedOptionsScreen(GuiScreen parent, GameSettings settings) {
+        this.parent = parent;
+        this.settings = settings;
     }
 
     @Override
-    protected final void onButtonClick(Button var1) {
-        if (var1.active) {
-            if (var1.id < 100) {
-                settings.toggleSetting(var1.id, 1);
-                var1.text = settings.getSetting(var1.id);
+    protected final void onButtonClick(Button clickedButton) {
+        if (clickedButton.active) {
+            if (clickedButton.id < 100) {
+                Setting affectedSetting = settingsOrder[clickedButton.id];
+                settings.toggleSetting(affectedSetting, 1);
+                clickedButton.text = settings.getSetting(affectedSetting);
 
             }
-                        if (var1.id == 100) {
+            if (clickedButton.id == 100) {
                 minecraft.setCurrentScreen(new CloudOptionsScreen(this, settings));
             }
 
-            if (var1.id == 200) {
+            if (clickedButton.id == 200) {
                 WaterLevelInputScreen screen = new WaterLevelInputScreen(parent, ""
                         + minecraft.level.waterLevel, height, "Enter new value for water level...");
                 screen.numbersOnly = true;
                 minecraft.setCurrentScreen(screen);
             }
-            if (var1.id == 300) {
+            if (clickedButton.id == 300) {
                 SkyColorInputScreen screen = new SkyColorInputScreen(parent, ""
                         + Integer.toHexString(minecraft.level.skyColor), height,
                         "Enter new value for sky color...");
@@ -63,7 +71,7 @@ public final class AdvancedOptionsScreen extends GuiScreen {
                 screen.stringLimit = 6;
                 minecraft.setCurrentScreen(screen);
             }
-            if (var1.id == 400) {
+            if (clickedButton.id == 400) {
                 FogColorInputScreen screen = new FogColorInputScreen(parent, ""
                         + Integer.toHexString(minecraft.level.fogColor), height,
                         "Enter new value for fog color...");
@@ -71,7 +79,7 @@ public final class AdvancedOptionsScreen extends GuiScreen {
                 screen.stringLimit = 6;
                 minecraft.setCurrentScreen(screen);
             }
-            if (var1.id == 500) {
+            if (clickedButton.id == 500) {
                 ColorCache c = minecraft.level.customLightColour;
                 Color color = new Color(255, 255, 255);
                 String colorString = "";
@@ -88,7 +96,7 @@ public final class AdvancedOptionsScreen extends GuiScreen {
                 screen.stringLimit = 6;
                 minecraft.setCurrentScreen(screen);
             }
-            if (var1.id == 600) {
+            if (clickedButton.id == 600) {
                 ColorCache c = minecraft.level.customShadowColour;
                 Color color = new Color(155, 155, 155);
                 String colorString = "";
@@ -106,7 +114,7 @@ public final class AdvancedOptionsScreen extends GuiScreen {
                 minecraft.setCurrentScreen(screen);
             }
 
-            if (var1.id == 700) {
+            if (clickedButton.id == 700) {
                 minecraft.setCurrentScreen(new OptionsScreen(this, settings));
             }
         }
@@ -114,29 +122,32 @@ public final class AdvancedOptionsScreen extends GuiScreen {
 
     @Override
     public final void onOpen() {
-        int heightSeperator = 0;
-        for (int var1 = 10; var1 < settings.settingCount; ++var1) {
-            buttons.add(new OptionButton(var1, width / 2 - 155 + heightSeperator % 2 * 160, height
-                    / 6 + 24 * (heightSeperator >> 1), settings.getSetting(var1)));
-            heightSeperator++;
+        int heightSeparator = 0;
+        for (int i = 0; i < settingsOrder.length; ++i) {
+            // TODO: advanced settings
+            buttons.add(new OptionButton(i,
+                    width / 2 - 155 + heightSeparator % 2 * 160,
+                    height / 6 + 24 * (heightSeparator >> 1),
+                    settings.getSetting(settingsOrder[i])));
+            heightSeparator++;
         }
-                buttons.add(new OptionButton(100, width / 2 - 155 + heightSeperator % 2 * 160, height / 6
-                + 24 * (heightSeperator >> 1), "Clouds"));
-        heightSeperator++;
-                buttons.add(new OptionButton(200, width / 2 - 155 + heightSeperator % 2 * 160, height / 6
-                + 24 * (heightSeperator >> 1), "Water Level"));
-        heightSeperator++;
-        buttons.add(new OptionButton(300, width / 2 - 155 + heightSeperator % 2 * 160, height / 6
-                + 24 * (heightSeperator >> 1), "Sky Color"));
-        heightSeperator++;
-        buttons.add(new OptionButton(400, width / 2 - 155 + heightSeperator % 2 * 160, height / 6
-                + 24 * (heightSeperator >> 1), "Fog Color"));
-        heightSeperator++;
-        buttons.add(new OptionButton(500, width / 2 - 155 + heightSeperator % 2 * 160, height / 6
-                + 24 * (heightSeperator >> 1), "Sunlight Color"));
-        heightSeperator++;
-        buttons.add(new OptionButton(600, width / 2 - 155 + heightSeperator % 2 * 160, height / 6
-                + 24 * (heightSeperator >> 1), "Shadow Color"));
+        buttons.add(new OptionButton(100, width / 2 - 155 + heightSeparator % 2 * 160, height / 6
+                + 24 * (heightSeparator >> 1), "Clouds"));
+        heightSeparator++;
+        buttons.add(new OptionButton(200, width / 2 - 155 + heightSeparator % 2 * 160, height / 6
+                + 24 * (heightSeparator >> 1), "Water Level"));
+        heightSeparator++;
+        buttons.add(new OptionButton(300, width / 2 - 155 + heightSeparator % 2 * 160, height / 6
+                + 24 * (heightSeparator >> 1), "Sky Color"));
+        heightSeparator++;
+        buttons.add(new OptionButton(400, width / 2 - 155 + heightSeparator % 2 * 160, height / 6
+                + 24 * (heightSeparator >> 1), "Fog Color"));
+        heightSeparator++;
+        buttons.add(new OptionButton(500, width / 2 - 155 + heightSeparator % 2 * 160, height / 6
+                + 24 * (heightSeparator >> 1), "Sunlight Color"));
+        heightSeparator++;
+        buttons.add(new OptionButton(600, width / 2 - 155 + heightSeparator % 2 * 160, height / 6
+                + 24 * (heightSeparator >> 1), "Shadow Color"));
 
         buttons.add(new Button(700, width / 2 - 100, height / 6 + 168, "Done"));
 

--- a/src/main/java/com/mojang/minecraft/gui/ControlsScreen.java
+++ b/src/main/java/com/mojang/minecraft/gui/ControlsScreen.java
@@ -46,7 +46,7 @@ public final class ControlsScreen extends GuiScreen {
                     * (var1 >> 1), settings.getBinding(var1)));
         }
                 buttons.add(new OptionButton(100, width / 2 - 77 + 10 % 2 * 160, height / 6 + 24
-                    * (10 >> 1), "More..."));
+                * (10 >> 1), "More..."));
 
         buttons.add(new Button(200, width / 2 - 100, height / 6 + 168, "Done"));
     }

--- a/src/main/java/com/mojang/minecraft/gui/FontRenderer.java
+++ b/src/main/java/com/mojang/minecraft/gui/FontRenderer.java
@@ -23,19 +23,19 @@ public final class FontRenderer {
     public FontRenderer(GameSettings settings, String fontImage, TextureManager textures)
             throws IOException {
         this.settings = settings;
-        BufferedImage font;
+        BufferedImage fontTexture;
 
         try {
-            font = ImageIO.read(TextureManager.class.getResourceAsStream(fontImage));
+            fontTexture = ImageIO.read(TextureManager.class.getResourceAsStream(fontImage));
         } catch (IOException e) {
             throw new IOException("Missing resource");
         }
-        int width = font.getWidth();
-        int height = font.getHeight();
+        int width = fontTexture.getWidth();
+        int height = fontTexture.getHeight();
         charWidth = width;
         charHeight = height;
         int[] fontData = new int[256 * 256];
-        font.getRGB(0, 0, width, height, fontData, 0, width);
+        fontTexture.getRGB(0, 0, width, height, fontData, 0, width);
 
         for (int character = 0; character < 256; ++character) {
             int var6 = character % 16;
@@ -119,12 +119,6 @@ public final class FontRenderer {
                     int blue = (code & 1) * 191 + intensity;
                     int green = ((code & 2) >> 1) * 191 + intensity;
                     int red = ((code & 4) >> 2) * 191 + intensity;
-                    if (settings.anaglyph) {
-                        intensity = (code * 30 + green * 59 + blue * 11) / 100;
-                        green = (code * 30 + green * 70) / 100;
-                        blue = (code * 30 + blue * 70) / 100;
-                        red = intensity;
-                    }
 
                     int c = red << 16 | green << 8 | blue;
                     if (shadow) {

--- a/src/main/java/com/mojang/minecraft/gui/GuiScreen.java
+++ b/src/main/java/com/mojang/minecraft/gui/GuiScreen.java
@@ -14,7 +14,7 @@ public class GuiScreen extends Screen {
     protected Minecraft minecraft;
     public int width;
     public int height;
-    protected List<Button> buttons = new ArrayList<Button>();
+    protected List<Button> buttons = new ArrayList<>();
     public boolean grabsMouse = false;
     protected FontRenderer fontRenderer;
 
@@ -26,23 +26,20 @@ public class GuiScreen extends Screen {
         while (Keyboard.next()) {
             keyboardEvent();
         }
-
     }
 
     public final void keyboardEvent() {
         if (Keyboard.getEventKeyState()) {
             onKeyPress(Keyboard.getEventCharacter(), Keyboard.getEventKey());
         }
-
     }
 
     public final void mouseEvent() {
         if (Mouse.getEventButtonState()) {
-            int var1 = Mouse.getEventX() * width / minecraft.width;
-            int var2 = height - Mouse.getEventY() * height / minecraft.height - 1;
-            onMouseClick(var1, var2, Mouse.getEventButton());
+            int mouseX = Mouse.getEventX() * width / minecraft.width;
+            int mouseY = height - Mouse.getEventY() * height / minecraft.height - 1;
+            onMouseClick(mouseX, mouseY, Mouse.getEventButton());
         }
-
     }
 
     protected void onButtonClick(Button var1) {
@@ -61,65 +58,64 @@ public class GuiScreen extends Screen {
         }
     }
 
-    protected void onMouseClick(int var1, int var2, int var3) {
-        if (var3 == 0) {
-            for (var3 = 0; var3 < buttons.size(); ++var3) {
-                Button var4;
-                Button var7;
-                if ((var7 = var4 = buttons.get(var3)).active && var1 >= var7.x && var2 >= var7.y
-                        && var1 < var7.x + var7.width && var2 < var7.y + var7.height) {
-                    onButtonClick(var4);
+    protected void onMouseClick(int mouseX, int mouseY, int mouseButton) {
+        if (mouseButton == 0) { // Left-click
+            for (Button button : buttons) {
+                if (button.active && mouseX >= button.x && mouseY >= button.y
+                        && mouseX < button.x + button.width && mouseY < button.y + button.height) {
+                    onButtonClick(button);
                 }
             }
         }
-
     }
 
     public void onOpen() {
     }
 
-    public final void open(Minecraft var1, int var2, int var3) {
-        minecraft = var1;
-        fontRenderer = var1.fontRenderer;
-        width = var2;
-        height = var3;
+    public final void open(Minecraft minecraft, int width, int height) {
+        this.minecraft = minecraft;
+        fontRenderer = minecraft.fontRenderer;
+        this.width = width;
+        this.height = height;
         onOpen();
     }
 
-    public void render(int var1, int var2) {
-        for (int var3 = 0; var3 < buttons.size(); ++var3) {
-            Button var10000 = buttons.get(var3);
-            Minecraft var7 = minecraft;
-            Button var4 = var10000;
-            if (var10000.visible) {
-                FontRenderer var8 = var7.fontRenderer;
-                GL11.glBindTexture(3553, var7.textureManager.load("/gui/gui.png"));
-                GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
-                byte var9 = 1;
-                boolean var6 = var1 >= var4.x && var2 >= var4.y && var1 < var4.x + var4.width
-                        && var2 < var4.y + var4.height;
-                if (!var4.active) {
-                    var9 = 0;
-                } else if (var6) {
-                    var9 = 2;
-                }
-
-                var4.drawImage(var4.x, var4.y, 0, 46 + var9 * 20, var4.width / 2, var4.height);
-                var4.drawImage(var4.x + var4.width / 2, var4.y, 200 - var4.width / 2,
-                        46 + var9 * 20, var4.width / 2, var4.height);
-                if (!var4.active) {
-                    drawCenteredString(var8, var4.text, var4.x + var4.width / 2, var4.y
-                            + (var4.height - 8) / 2, -6250336);
-                } else if (var6) {
-                    drawCenteredString(var8, var4.text, var4.x + var4.width / 2, var4.y
-                            + (var4.height - 8) / 2, 16777120);
-                } else {
-                    drawCenteredString(var8, var4.text, var4.x + var4.width / 2, var4.y
-                            + (var4.height - 8) / 2, 14737632);
-                }
+    public void render(int mouseX, int mouseY) {
+        for (Button button : buttons) {
+            if (!button.visible) {
+                continue;
             }
-        }
 
+            GL11.glBindTexture(GL11.GL_TEXTURE_2D, minecraft.textureManager.load("/gui/gui.png"));
+            GL11.glColor4f(1.0F, 1.0F, 1.0F, 1.0F);
+            byte spriteOffset = 1;
+            boolean isHovered = (mouseX >= button.x) && (mouseY >= button.y)
+                    && (mouseX < button.x + button.width)
+                    && (mouseY < button.y + button.height);
+            if (!button.active) {
+                spriteOffset = 0;
+            } else if (isHovered) {
+                spriteOffset = 2;
+            }
+
+            button.drawImage(button.x, button.y,
+                    0, 46 + spriteOffset * 20, button.width / 2, button.height);
+            button.drawImage(button.x + button.width / 2, button.y,
+                    200 - button.width / 2, 46 + spriteOffset * 20, button.width / 2, button.height);
+
+            int textColorRGBA;
+            if (!button.active) {
+                textColorRGBA = -6250336; // A0A0A0FF
+            } else if (isHovered) {
+                textColorRGBA = 16777120; // A0FFFF00
+            } else {
+                textColorRGBA = 14737632; // E0E0E000
+            }
+
+            drawCenteredString(minecraft.fontRenderer, button.text,
+                    button.x + button.width / 2, button.y + (button.height - 8) / 2,
+                    textColorRGBA);
+        }
     }
 
     public void tick() {

--- a/src/main/java/com/mojang/minecraft/gui/OptionsScreen.java
+++ b/src/main/java/com/mojang/minecraft/gui/OptionsScreen.java
@@ -1,59 +1,86 @@
 package com.mojang.minecraft.gui;
 
 import com.mojang.minecraft.GameSettings;
+import com.mojang.minecraft.Setting;
 
 public final class OptionsScreen extends GuiScreen {
 
-    private String title = "Options";
-    private GameSettings settings;
+    private final static Setting[] settingsOrder = new Setting[]{
+        Setting.MUSIC, Setting.SOUND,
+        Setting.INVERT_MOUSE, Setting.VIEW_BOBBING,
+        Setting.RENDER_DISTANCE, Setting.LIMIT_FRAMERATE,
+        Setting.SMOOTHING, Setting.ANISOTROPIC,
+        Setting.FONT_SCALE, Setting.SHOW_NAMES
+    };
 
-    public OptionsScreen(GuiScreen var1, GameSettings var2) {
-        settings = var2;
+    private final String title = "Options";
+    private final GameSettings settings;
+
+    public OptionsScreen(GuiScreen parent, GameSettings settings) {
+        this.settings = settings;
     }
 
     @Override
-    protected final void onButtonClick(Button var1) {
-        if (var1.active) {
-            if (var1.id < 100) {
-                settings.toggleSetting(var1.id, 1);
-                var1.text = settings.getSetting(var1.id);
-            }
-            buttons.get(9).active = minecraft.settings.smoothing > 0;
+    protected final void onButtonClick(Button clickedButton) {
+        if (clickedButton.active) {
+            if (clickedButton.id < 100) {
+                // A settings button was clicked
+                Setting affectedSetting = settingsOrder[clickedButton.id];
+                settings.toggleSetting(affectedSetting, 1);
+                clickedButton.text = settings.getSetting(affectedSetting);
+                checkSettingsConsistency();
 
-            if (var1.id == 100) {
+            } else if (clickedButton.id == 100) {
+                // [Advanced Options] was clicked
                 minecraft.setCurrentScreen(new AdvancedOptionsScreen(this, settings));
-            }
 
-            if (var1.id == 200) {
+            } else if (clickedButton.id == 200) {
+                // [Controls] was clicked
                 minecraft.setCurrentScreen(new ControlsScreen(this, settings));
-            }
 
-            if (var1.id == 300) {
+            } else if (clickedButton.id == 300) {
+                // [Done] was clicked
                 minecraft.setCurrentScreen(new PauseScreen());
             }
-
         }
     }
 
     @Override
     public final void onOpen() {
-        for (int var1 = 0; var1 < 10; ++var1) {
-            buttons.add(new OptionButton(var1, width / 2 - 155 + var1 % 2 * 160, height / 6 + 24
-                    * (var1 >> 1), settings.getSetting(var1)));
+        for (int i = 0; i < settingsOrder.length; ++i) {
+            buttons.add(new OptionButton(i,
+                    width / 2 - 155 + (i % 2) * 160,
+                    height / 6 + 24 * (i / 2),
+                    settings.getSetting(settingsOrder[i])));
         }
+        checkSettingsConsistency();
 
         buttons.add(new Button(100, width / 2 - 100, height / 6 + 90 + 32, "Advanced Options..."));
 
         buttons.add(new Button(200, width / 2 - 100, height / 6 + 120 + 26, "Controls..."));
         buttons.add(new Button(300, width / 2 - 100, height / 6 + 168, "Done"));
-
-        buttons.get(9).active = minecraft.settings.smoothing > 0;
     }
 
     @Override
-    public final void render(int var1, int var2) {
+    public final void render(int mouseX, int mouseY) {
         drawFadingBox(0, 0, width, height, 1610941696, -1607454624);
         drawCenteredString(fontRenderer, title, width / 2, 20, 16777215);
-        super.render(var1, var2);
+        super.render(mouseX, mouseY);
+    }
+
+    private void checkSettingsConsistency() {
+        // [Anisotropic] should only ne enabled if smoothing is on
+        boolean smoothingOn = (minecraft.settings.smoothing > 0);
+        buttons.get(indexOf(Setting.ANISOTROPIC, settingsOrder)).active = smoothingOn;
+    }
+
+    private static <T> int indexOf(T needle, T[] haystack) {
+        for (int i = 0; i < haystack.length; i++) {
+            if (haystack[i] != null && haystack[i].equals(needle)
+                    || needle == null && haystack[i] == null) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/src/main/java/com/mojang/minecraft/gui/Screen.java
+++ b/src/main/java/com/mojang/minecraft/gui/Screen.java
@@ -130,21 +130,17 @@ public class Screen {
         GL11.glAlphaFunc(516, 0.5F);
     }
 
-    protected float imgZ = 0.0F;
+    protected float imgZ = 0;
 
-    public final void drawImage(int var1, int var2, int var3, int var4,
-            int var5, int var6) {
+    public final void drawImage(int screenX, int screenY, int u, int v, int width, int height) {
         float var7 = 0.00390625F;
         float var8 = 0.00390625F;
-        ShapeRenderer var9 = ShapeRenderer.instance;
-        ShapeRenderer.instance.begin();
-        var9.vertexUV(var1, var2 + var6, imgZ, var3 * var7, (var4 + var6)
-                * var8);
-        var9.vertexUV(var1 + var5, var2 + var6, imgZ, (var3 + var5) * var7,
-                (var4 + var6) * var8);
-        var9.vertexUV(var1 + var5, var2, imgZ, (var3 + var5) * var7, var4
-                * var8);
-        var9.vertexUV(var1, var2, imgZ, var3 * var7, var4 * var8);
-        var9.end();
+        ShapeRenderer renderer = ShapeRenderer.instance;
+        renderer.begin();
+        renderer.vertexUV(screenX, screenY + height, imgZ, u * var7, (v + height) * var8);
+        renderer.vertexUV(screenX + width, screenY + height, imgZ, (u + width) * var7, (v + height) * var8);
+        renderer.vertexUV(screenX + width, screenY, imgZ, (u + width) * var7, v * var8);
+        renderer.vertexUV(screenX, screenY, imgZ, u * var7, v * var8);
+        renderer.end();
     }
 }

--- a/src/main/java/com/mojang/minecraft/render/Renderer.java
+++ b/src/main/java/com/mojang/minecraft/render/Renderer.java
@@ -134,26 +134,12 @@ public final class Renderer {
                 var7 = 0.4F;
                 var8 = 0.4F;
                 var3 = 0.9F;
-                if (minecraft.settings.anaglyph) {
-                    var4 = (var7 * 30.0F + var8 * 59.0F + var3 * 11.0F) / 100.0F;
-                    var8 = (var7 * 30.0F + var8 * 70.0F) / 100.0F;
-                    var3 = (var7 * 30.0F + var3 * 70.0F) / 100.0F;
-                    var7 = var4;
-                }
-
                 GL11.glLightModel(2899, createBuffer(var7, var8, var3, 1.0F));
             } else if (var6 == LiquidType.lava) {
                 GL11.glFogf(2914, 2.0F);
                 var7 = 0.4F;
                 var8 = 0.3F;
                 var3 = 0.3F;
-                if (minecraft.settings.anaglyph) {
-                    var4 = (var7 * 30.0F + var8 * 59.0F + var3 * 11.0F) / 100.0F;
-                    var8 = (var7 * 30.0F + var8 * 70.0F) / 100.0F;
-                    var3 = (var7 * 30.0F + var3 * 70.0F) / 100.0F;
-                    var7 = var4;
-                }
-
                 GL11.glLightModel(2899, createBuffer(var7, var8, var3, 1.0F));
             }
         } else {

--- a/src/main/java/com/mojang/minecraft/render/texture/TextureFX.java
+++ b/src/main/java/com/mojang/minecraft/render/texture/TextureFX.java
@@ -4,7 +4,6 @@ public class TextureFX {
     public byte[] textureData = new byte[1024];
 
     public int textureId;
-    public boolean anaglyph = false;
     public int scaling = 1;
 
     public TextureFX(int textureID) {

--- a/src/main/java/com/mojang/minecraft/render/texture/TextureFireFX.java
+++ b/src/main/java/com/mojang/minecraft/render/texture/TextureFireFX.java
@@ -59,14 +59,6 @@ public class TextureFireFX extends TextureFX {
                 c = '\0';
             }
             f2 = (f2 - 0.5F) * 2.0F;
-            if (anaglyph) {
-                int l2 = (k1 * 30 + i2 * 59 + k2 * 11) / 100;
-                int i3 = (k1 * 30 + i2 * 70) / 100;
-                int j3 = (k1 * 30 + k2 * 70) / 100;
-                k1 = l2;
-                i2 = i3;
-                k2 = j3;
-            }
             textureData[l * 4 + 0] = (byte) k1;
             textureData[l * 4 + 1] = (byte) i2;
             textureData[l * 4 + 2] = (byte) k2;

--- a/src/main/java/com/mojang/minecraft/render/texture/TextureLavaFX.java
+++ b/src/main/java/com/mojang/minecraft/render/texture/TextureLavaFX.java
@@ -72,15 +72,6 @@ public final class TextureLavaFX extends TextureFX {
             var5 = (int) (var3 * 100.0F + 155.0F);
             var6 = (int) (var3 * var3 * 255.0F);
             var7 = (int) (var3 * var3 * var3 * var3 * 128.0F);
-            if (anaglyph) {
-                var8 = (var5 * 30 + var6 * 59 + var7 * 11) / 100;
-                var9 = (var5 * 30 + var6 * 70) / 100;
-                var1 = (var5 * 30 + var7 * 70) / 100;
-                var5 = var8;
-                var6 = var9;
-                var7 = var1;
-            }
-
             textureData[var2 << 2] = (byte) var5;
             textureData[(var2 << 2) + 1] = (byte) var6;
             textureData[(var2 << 2) + 2] = (byte) var7;

--- a/src/main/java/com/mojang/minecraft/render/texture/TextureWaterFX.java
+++ b/src/main/java/com/mojang/minecraft/render/texture/TextureWaterFX.java
@@ -67,15 +67,6 @@ public final class TextureWaterFX extends TextureFX {
             var6 = (int) (50.0F + var9 * 64.0F);
             var1 = 255;
             int var10 = (int) (146.0F + var9 * 50.0F);
-            if (anaglyph) {
-                var1 = (var5 * 30 + var6 * 59 + 2805) / 100;
-                var4 = (var5 * 30 + var6 * 70) / 100;
-                int var7 = (var5 * 30 + 17850) / 100;
-                var5 = var1;
-                var6 = var4;
-                var1 = var7;
-            }
-
             textureData[var2 << 2] = (byte) var5;
             textureData[(var2 << 2) + 1] = (byte) var6;
             textureData[(var2 << 2) + 2] = (byte) var1;


### PR DESCRIPTION
- Overhauled GameSettings. Use Settings enum instead of integer literals to work with settings.
- Made the settings file parser more permissive: key names are now case-insensitive, "true" literal is also case-insensitive, and "1" is accepted in its place.
- Took out 3D Anaglyph functionality.
- Updated [Options] and [Advanced Options] screens -- some settings have been rearranged.
- Changed [Anisotropic] setting to allow different anosotropy levels, instead of just being on/off.
