### PR TITLE
Upgraded LWJGL to 2.9.1 and JInput to 2.0.5.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,27 +23,27 @@
         <dependency>
             <groupId>org.lwjgl.lwjgl</groupId>
             <artifactId>lwjgl</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.lwjgl.lwjgl</groupId>
             <artifactId>lwjgl_util</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.1</version>
         </dependency>
         <dependency>
             <groupId>net.java.jinput</groupId>
             <artifactId>jinput</artifactId>
-            <version>2.0.4</version>
+            <version>2.0.5</version>
         </dependency>
         <dependency>
             <groupId>org.lwjgl.lwjgl</groupId>
             <artifactId>lwjgl_util_applet</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.1</version>
         </dependency>
         <dependency>
             <groupId>org.lwjgl.lwjgl</groupId>
             <artifactId>lwjgl-platform</artifactId>
-            <version>2.9.0</version>
+            <version>2.9.1</version>
             <type>pom</type>
         </dependency>
     </dependencies>


### PR DESCRIPTION
If you use the ClassiCubeLauncher and want to use LWJGL 2.9.1 now, you will have to use a special version that will not force LWJGL downgrade: http://www.fcraft.net/ccc/ClassiCubeLauncher58-LibVerificationDisabled.jar

You will also need to make sure that LWJGL 2.9.1 binaries are in your library path. You can get it from http://lwjgl.org/download.php

...or, for your convenience, here are exact files you need in <code>.net.classicube.client</code>:
- Windows binaries: http://www.fcraft.net/ccc/LWJGL_2.9.1_Win.zip
- Linux binaries: http://www.fcraft.net/ccc/LWJGL_2.9.1_Linux.zip
