### PR TITLE
Fixed frustum culling not working. (thanks 123DMWM)

### DIFF
--- a/src/main/java/com/mojang/minecraft/Minecraft.java
+++ b/src/main/java/com/mojang/minecraft/Minecraft.java
@@ -1021,7 +1021,6 @@ public final class Minecraft implements Runnable {
                         Level level = renderer.minecraft.level;
                         LevelRenderer levelRenderer = renderer.minecraft.levelRenderer;
                         ParticleManager particleManager = renderer.minecraft.particleManager;
-                        Frustum frustum = FrustumImpl.getInstance();
 
                         GL11.glViewport(0, 0, renderer.minecraft.width, renderer.minecraft.height);
                         float viewDistanceFactor = 1F - (float) (Math.pow(
@@ -1104,7 +1103,8 @@ public final class Minecraft implements Runnable {
                         var74 = player.yo + (player.y - player.yo) * delta;
                         var33 = player.zo + (player.z - player.zo) * delta;
                         GL11.glTranslatef(-var69, -var74, -var33);
-
+                        Frustum frustum = FrustumImpl.getInstance();
+                        
                         for (i = 0; i < levelRenderer.chunkCache.length; ++i) {
                             levelRenderer.chunkCache[i].clip(frustum);
                         }


### PR DESCRIPTION
Shamelessly quoted from https://github.com/andrewphorn/ClassiCube-Client/commit/25410ec843d302eb8cb9647b58fbbb0935964f07#commitcomment-5639961: 

> The last 32 blocks along the X axis are invisible on a 512x512 map.

This should fix the issue. (and increase performance)
