### PR TITLE
Fixes crashing in BlockSelectScreen.

### DIFF
--- a/src/main/java/com/mojang/minecraft/Minecraft.java
+++ b/src/main/java/com/mojang/minecraft/Minecraft.java
@@ -2684,7 +2684,11 @@ public final class Minecraft implements Runnable {
                         break;
                     }
                 }
-                currentScreen.keyboardEvent();
+                // If the player presses lots of keys and presses the left mouse button,
+                // sometimes the screen is closed even though there are still keys left to process.
+                if (currentScreen != null) {
+                    currentScreen.keyboardEvent();
+                }
             }
         } else if (currentScreen == null) {
             while (Mouse.next()) {


### PR DESCRIPTION
Should fix issue #141.

How to reproduce the bug:
Basically button mash any keys and press the left mouse button while in BlockSelectScreen.
