### PR TITLE
Avoided rendering chunks in render pass 2 twice.

### DIFF
--- a/src/main/java/com/mojang/minecraft/Minecraft.java
+++ b/src/main/java/com/mojang/minecraft/Minecraft.java
@@ -1386,18 +1386,9 @@ public final class Minecraft implements Runnable {
                                 levelRenderer.textureManager.load("/water.png"));
 
                         GL11.glCallList(levelRenderer.listId + 1);
-                        GL11.glDisable(GL11.GL_BLEND);
                         GL11.glEnable(GL11.GL_BLEND);
-                        GL11.glColorMask(false, false, false, false);
 
-                        var120 = levelRenderer.sortChunks(player, 1);
-                        GL11.glColorMask(true, true, true, true);
-
-                        if (var120 > 0) {
-                            GL11.glBindTexture(GL11.GL_TEXTURE_2D,
-                                    levelRenderer.textureManager.load("/terrain.png"));
-                            GL11.glCallLists(levelRenderer.buffer);
-                        }
+                        levelRenderer.sortChunks(player, 1);
 
                         GL11.glDepthMask(true);
                         GL11.glDisable(GL11.GL_BLEND);

--- a/src/main/java/com/mojang/minecraft/render/LevelRenderer.java
+++ b/src/main/java/com/mojang/minecraft/render/LevelRenderer.java
@@ -231,7 +231,7 @@ public final class LevelRenderer {
         GL11.glEndList();
     }
 
-    public final int sortChunks(Player player, int renderPass) {
+    public final void sortChunks(Player player, int renderPass) {
         float distX = player.x - lastLoadX;
         float distY = player.y - lastLoadY;
         float distZ = player.z - lastLoadZ;
@@ -243,8 +243,8 @@ public final class LevelRenderer {
         }
 
         int count = 0;
-        for (Chunk aLoadQueue : loadQueue) {
-            count = aLoadQueue.appendLists(chunkDataCache, count, renderPass);
+        for (Chunk chunk : loadQueue) {
+            count = chunk.appendLists(chunkDataCache, count, renderPass);
         }
 
         buffer.clear();
@@ -254,7 +254,5 @@ public final class LevelRenderer {
             GL11.glBindTexture(GL11.GL_TEXTURE_2D, textureManager.load("/terrain.png"));
             GL11.glCallLists(buffer);
         }
-
-        return buffer.remaining();
     }
 }


### PR DESCRIPTION
Fixes chunks in render pass 2 redundantly being rendered twice. 

FPS improvements in the world I tested this commit in ranged from 3 - 10. There did not appear to be any issues introduced related to rendering. (though I may be wrong)
