### PR TITLE
Simplified timing code (remove adjustment based on currentTimeMillis)

### DIFF
--- a/src/main/java/com/mojang/minecraft/Minecraft.java
+++ b/src/main/java/com/mojang/minecraft/Minecraft.java
@@ -881,27 +881,10 @@ public final class Minecraft implements Runnable {
         }
 
         try {
-            long clockNow = System.currentTimeMillis(); // system's clock time
-            long actualNow = System.nanoTime() / 1000000L; // JRE's internal counter
-            long clockTimeSinceLastFrame = clockNow - timer.lastSysClock;
-            if (clockTimeSinceLastFrame > 1000L) {
-                // Over 1 second has elapsed since last frame.
-                long clockError = actualNow - timer.lastHRClock;
-                double clockAdjustmentRatio = clockTimeSinceLastFrame / (double) clockError;
-                timer.adjustment += (clockAdjustmentRatio - timer.adjustment) * 0.20000000298023224D;
-                timer.lastSysClock = clockNow;
-                timer.lastHRClock = actualNow;
-            }
-
-            if (clockTimeSinceLastFrame < 0L) {
-                // Negative time elapsed! System clock probably changed.
-                timer.lastSysClock = clockNow;
-                timer.lastHRClock = actualNow;
-            }
-
-            double actualNowSeconds = actualNow / 1000D;
-            double secondsPassed = (actualNowSeconds - timer.lastHR) * timer.adjustment;
-            timer.lastHR = actualNowSeconds;
+            // Get current time in seconds 
+            double now = System.nanoTime() / 1000000000D;
+            double secondsPassed = (now - timer.lastHR);
+            timer.lastHR = now;
 
             // Cap seconds-passed to range [0,1]
             if (secondsPassed < 0D) {

--- a/src/main/java/com/mojang/util/Timer.java
+++ b/src/main/java/com/mojang/util/Timer.java
@@ -8,13 +8,10 @@ public class Timer {
     public float delta;
     public float speed = 1F;
     public float elapsedDelta = 0F;
-    public long lastSysClock;
     public long lastHRClock;
-    public double adjustment = 1D;
 
     public Timer(float tps) {
         this.tps = tps;
-        lastSysClock = System.currentTimeMillis();
         lastHRClock = System.nanoTime() / 1000000L;
     }
 }


### PR DESCRIPTION
Keeping track of wall-clock time (which is subject to adjustment, DST, timezones, etc) in addition to internal high-res timer provides no benefit. Here is how the old code worked:

"secondsPassed" variable is the key to figuring out how many ticks passed. That value is determined by the frame-to-frame delta of JRE's high-res timer (System.nanoTime()). So far so good. But then it gets adjusted by "timer.adjustment" variable. That value starts at 1.0 and is affected any time wall-clock time delta exceeds 1 second between frames. If wall-clock time delta is over 1s, the following value is added to "timer.adjustment":  (wall_clock_delta / HR_clock_delta - timer.adjustment)*0.2

Some scenarios for frame-to-frame wall-clock delta being over 1s: 1) really laggy frame (e.g. first frame after map load), 2) NTP clock adjustment, 3) DST transition, 4) timezone transition, 5) computer waking up from sleep. In all of these scenarios, adjustment would simply result in odd tick rates, and would provide no benefit.

After much research, I found no examples of this adjustment technique being used in any game loops (outside Notch's original code). So I have removed it. I've tested the game with this commit, and it performs just fine at all framerates.
