### PR TITLE
Fixed ClassicWorld format compliance in LevelSerialzier

### DIFF
--- a/src/main/java/com/mojang/minecraft/level/LevelSerializer.java
+++ b/src/main/java/com/mojang/minecraft/level/LevelSerializer.java
@@ -64,7 +64,7 @@ public class LevelSerializer {
         master.setCompoundTag("Spawn", spawn);
         
         // Metadata tag is required by ClassicWorld specs, even if empty.
-        master.setCompoundTag("Metadata", new NBTTagCompound("Metadata");
+        master.setCompoundTag("Metadata", new NBTTagCompound("Metadata"));
 
         String fileName = fullFilePath
                 + (fullFilePath.getAbsolutePath().endsWith(EXT) ? "" : EXT);


### PR DESCRIPTION
The Metadata tag is required by ClassicWorld specs, even if empty.
