### PR TITLE
Reworked chunk update limiting and fog.

### DIFF
--- a/src/main/java/com/mojang/minecraft/GameSettings.java
+++ b/src/main/java/com/mojang/minecraft/GameSettings.java
@@ -33,7 +33,7 @@ public final class GameSettings {
     public static final int HACKTYPE_NORMAL = 0,
             HACKTYPE_ADVANCED = 1;
     private static final String[] viewDistanceOptions = new String[]{
-            "FAR", "NORMAL", "SHORT", "TINY"
+        "TINY (8)", "TINY (16)", "SHORT (32)", "SHORT (64)", "NORMAL (128)", "NORMAL (256)", "FAR (512)", "FAR (1024)"
     };
     // valid range of values for viewDistance
     public static final int VIEWDISTANCE_MIN = 0,
@@ -134,8 +134,8 @@ public final class GameSettings {
                 return "Invert mouse: " + toOnOff(invertMouse);
             case SHOW_DEBUG:
                 return "Show Debug: " + toOnOff(showDebug);
-            case RENDER_DISTANCE:
-                return "Render distance: " + viewDistanceOptions[viewDistance];
+            case VIEW_DISTANCE:
+                return "View distance: " + viewDistanceOptions[viewDistance];
             case VIEW_BOBBING:
                 return "View bobbing: " + toOnOff(viewBobbing);
             case LIMIT_FRAMERATE:
@@ -304,7 +304,7 @@ public final class GameSettings {
             case SHOW_DEBUG:
                 showDebug = !showDebug;
                 break;
-            case RENDER_DISTANCE:
+            case VIEW_DISTANCE:
                 int newViewDist = viewDistance + fogValue;
                 if (newViewDist < VIEWDISTANCE_MIN) {
                     newViewDist = VIEWDISTANCE_MAX;

--- a/src/main/java/com/mojang/minecraft/Setting.java
+++ b/src/main/java/com/mojang/minecraft/Setting.java
@@ -3,7 +3,7 @@ package com.mojang.minecraft;
 public enum Setting {
     MUSIC,              SOUND,
     INVERT_MOUSE,       SHOW_DEBUG,
-    RENDER_DISTANCE,    VIEW_BOBBING,
+    VIEW_DISTANCE,    VIEW_BOBBING,
     LIMIT_FRAMERATE,    SMOOTHING,
     ANISOTROPIC,        ALLOW_SERVER_TEXTURES,
     SPEEDHACK_TYPE,     FONT_SCALE,

--- a/src/main/java/com/mojang/minecraft/gui/OptionsScreen.java
+++ b/src/main/java/com/mojang/minecraft/gui/OptionsScreen.java
@@ -6,7 +6,7 @@ import com.mojang.minecraft.Setting;
 public final class OptionsScreen extends GuiScreen {
 
     private final static Setting[] settingsOrder = new Setting[]{Setting.MUSIC, Setting.SOUND,
-            Setting.INVERT_MOUSE, Setting.VIEW_BOBBING, Setting.RENDER_DISTANCE,
+            Setting.INVERT_MOUSE, Setting.VIEW_BOBBING, Setting.VIEW_DISTANCE,
             Setting.LIMIT_FRAMERATE, Setting.SMOOTHING, Setting.ANISOTROPIC, Setting.FONT_SCALE,
             Setting.SHOW_NAMES};
 

--- a/src/main/java/com/mojang/minecraft/render/Renderer.java
+++ b/src/main/java/com/mojang/minecraft/render/Renderer.java
@@ -20,8 +20,9 @@ import org.lwjgl.BufferUtils;
 import org.lwjgl.opengl.GL11;
 
 public final class Renderer {
-    // TODO: adaptive chunk update rate, based on framerate
-    public static final int MAX_CHUNK_UPDATES_PER_FRAME = 4;
+
+    public static final int MIN_CHUNK_UPDATES_PER_FRAME = 4;
+    public static int dynamicChunkUpdateLimit = MIN_CHUNK_UPDATES_PER_FRAME;
 
     public Minecraft minecraft;
     public float fogColorMultiplier = 1F;
@@ -143,7 +144,7 @@ public final class Renderer {
                 float blue = 0.9F;
                 GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, createBuffer(red, green, blue, 1F));
             } else if (liquidType == LiquidType.lava) {
-                GL11.glFogf(GL11.GL_FOG_DENSITY, 2F);
+                GL11.glFogf(GL11.GL_FOG_DENSITY, 1.5F);
                 float red = 0.4F;
                 float green = 0.3F;
                 float blue = 0.3F;
@@ -152,7 +153,7 @@ public final class Renderer {
         } else {
             // Regular fog, when not in liquid
             GL11.glFogi(GL11.GL_FOG_MODE, GL11.GL_LINEAR);
-            GL11.glFogf(GL11.GL_FOG_START, 0F);
+            GL11.glFogf(GL11.GL_FOG_START, fogEnd / 2);
             GL11.glFogf(GL11.GL_FOG_END, fogEnd);
             GL11.glLightModel(GL11.GL_LIGHT_MODEL_AMBIENT, createBuffer(1F, 1F, 1F, 1F));
         }

--- a/src/main/java/com/mojang/util/Timer.java
+++ b/src/main/java/com/mojang/util/Timer.java
@@ -1,6 +1,7 @@
 package com.mojang.util;
 
 public class Timer {
+    public static final double NANOSEC_PER_SEC = 1000000000D;
     public float tps;
 
     public double lastHR;
@@ -9,6 +10,9 @@ public class Timer {
     public float speed = 1F;
     public float elapsedDelta = 0F;
     public long lastHRClock;
+    
+    public double syncTime;
+    public double chunkUpdateTime;
 
     public Timer(float tps) {
         this.tps = tps;


### PR DESCRIPTION
1. Max number of chunk updates per frame is determined dynamically/adaptively when vsync/framerate-limit is on. Number of updates is determined by measuring the approximate amount of time each update takes and the amount of time vsync wastes idling. Extra updates are done when there is enough idle time.
2. Added 2 new fog settings (SHORTER and FARTHER) and reworked the other settings. Previously fog distances were {8,32,128,512}. Now they are {8,16,32,64,128,256,512,1024}. Fog now starts further away from the camera, to prevent a washed-out look. "Render distance" label in settings changed to "View distance".

Signed-off-by: fragmer me@matvei.org
