### PR TITLE
Don't use ice physics when noclipping, fix +ophax

### DIFF
--- a/src/main/java/com/mojang/minecraft/mob/Mob.java
+++ b/src/main/java/com/mojang/minecraft/mob/Mob.java
@@ -505,7 +505,7 @@ public class Mob extends Entity {
             yd *= 0.98F;
             zd *= 0.91F;
             yd = (float) (yd - 0.08D);
-            if (Block.blocks[var1] != Block.ICE) {
+            if (Block.blocks[var1] != Block.ICE || noPhysics) {
 
                 if (flyingMode) {
                     y1 = 0F;

--- a/src/main/java/com/mojang/minecraft/net/PacketHandler.java
+++ b/src/main/java/com/mojang/minecraft/net/PacketHandler.java
@@ -111,11 +111,11 @@ public final class PacketHandler {
             // Read WoM-style hack control flags
             //TODO: if(!isExtEnabled(ProtocolExtension.HACK_CONTROL)){ ... }
             minecraft.womConfig.readHax(name, motd);
+            minecraft.player.userType = (Byte) packetParams[3];
             if (!receivedExtInfo) {
                 // Only process WoM-style "cfg" command if CPE is not enabled
                 minecraft.womConfig.readCfg(motd);
             }
-            minecraft.player.userType = (Byte) packetParams[3];
             setLoadingLevel(true);
             if (minecraft.womConfig.isEnabled() && minecraft.womConfig.hasKey("server.sendwomid")) {
                 String womIdCmd = "/womid ClassiCube" + Constants.CLASSICUBE_VERSION;


### PR DESCRIPTION
* Disable the ice skating effect if noclipping and flying through  an ice block. Fixes issue #315.
* Set user type before reading WoM hacks options. Fixes bug where ops would not be allowed to hack if only +ophax was set and the server only sent one authentication packet.