### PR TITLE
Removed shading from entities

### DIFF
--- a/src/main/java/com/mojang/minecraft/render/Renderer.java
+++ b/src/main/java/com/mojang/minecraft/render/Renderer.java
@@ -119,8 +119,8 @@ public final class Renderer {
             GL11.glEnable(GL11.GL_LIGHT0);
             GL11.glEnable(GL11.GL_COLOR_MATERIAL);
             GL11.glColorMaterial(GL11.GL_FRONT_AND_BACK, GL11.GL_AMBIENT_AND_DIFFUSE);
-            float ambientBrightness = 0.7F;
-            float diffuseBrightness = 0.3F;
+            float ambientBrightness = 1F;
+            float diffuseBrightness = 0F;
             Vec3D sunPosition = new Vec3D(0F, -1F, 0.5F).normalize();
             GL11.glLight(GL11.GL_LIGHT0, GL11.GL_POSITION,
                     createBuffer(sunPosition.x, sunPosition.y, sunPosition.z, 0F));


### PR DESCRIPTION
Removed the shading that is applied to the faces of entities in order to
give skins more control over their colors.

Note that this doesn't have anything to do with entities being shadowed
by blocks. They will still work normally.

Comparison: https://dl.dropboxusercontent.com/u/12694594/difference.png
